### PR TITLE
Add notes around mix.exs config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ def deps do
 end
 ```
 
+Be sure to include `event_bus` in your `mix.exs` Mixfile:
+
+```elixir
+def application do
+  [
+    applications: [
+      # ...
+      :event_bus
+    ]
+  ]
+end
+```
+
 ## Usage
 
 ##### Register event topics in `config.exs`
@@ -234,7 +247,7 @@ EventBus.topic_exist?(:metrics_updated)
 
 ##### Use block builder to build `EventBus.Model.Event` struct
 
-Builder automatically sets initialized_at and occured_at attributes
+Builder automatically sets `initialized_at` and `occurred_at` attributes
 ```elixir
 use EventBus.EventSource
 
@@ -279,7 +292,7 @@ end
 
 ##### Use block notifier to notify event data to given topic
 
-Builder automatically sets initialized_at and occured_at attributes
+Builder automatically sets `initialized_at` and `occurred_at` attributes
 ```elixir
 use EventBus.EventSource
 


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description

This adds notes in the README around configuring `:event_bus` as part of the application supervision tree.

### Changes

- [x] Add notes in README

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Updated readme

### References

- Issue #15
