### PR TITLE
Change time to utc and honor integer contract

### DIFF
--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -20,7 +20,7 @@ defmodule EventBus.EventSource do
   """
   defmacro build(params, do: yield) do
     quote do
-      initialized_at = System.os_time(:micro_seconds)
+      initialized_at = DateTime.utc_now |> DateTime.to_unix(:microseconds)
       params = unquote(params)
 
       source =
@@ -41,7 +41,7 @@ defmodule EventBus.EventSource do
         transaction_id: params[:transaction_id],
         data: data,
         initialized_at: initialized_at,
-        occurred_at: System.os_time(:micro_seconds),
+        occurred_at: DateTime.utc_now |> DateTime.to_unix(:microseconds),
         source: source,
         ttl: params[:ttl]
       }


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Change Datetime to UTC in order to avoid time shifting on local os. Also System.os_time returns a time_unit :: integer and breaks the contract you have in your struct. This makes dialyzer complain about broken contract

### Changes

- [X] Issue-23

### Is it ready?

- [X] Created an issue and defined what the problem is
- [X] Fixed the defined issue
- [X] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [X] The changes don't break current functionality
- [X] All tests are covered and passing travis
- [X] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [X] Added specs and docs if a new function introduced
- [NA] Updated specs and docs if changed any params of a function
- [NA] Updated changelog
- [NA] Updated readme
- [X] Didn't bump the version

### References

- Issue 23
