### PR TITLE
Update time spent calculation for EventSource block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.X]
 
+
+- Update time spent calculation for EventSource block
 - Remove support for system event tracing (Updated the wiki to create wrapper for system event tracing)
 
 ## [1.2.X] - 2018.02.24

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ end
 
 ## Traceability
 
-EventBus comes with a good enough data structure to track the event life cycle with its optional parameters. For a traceable system, it is highly recommend to fill optional fields on event data. It is also encouraged to use `Event.nofify` block/yield to automatically set the `initialized_at` and `occurred_at` values.
+EventBus comes with a good enough data structure to track the event life cycle with its optional parameters. For a traceable system, it is highly recommend to fill optional fields on event data. It is also encouraged to use `EventSource.nofify` block/yield to automatically set the `initialized_at` and `occurred_at` values.
 
 ### System Events
 

--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -9,6 +9,7 @@ defmodule EventBus.EventSource do
   defmacro __using__(_) do
     quote do
       require EventBus.EventSource
+
       alias EventBus.EventSource
       alias EventBus.Model.Event
     end
@@ -20,6 +21,7 @@ defmodule EventBus.EventSource do
   """
   defmacro build(params, do: yield) do
     quote do
+      started_at = System.monotonic_time(:micro_seconds)
       initialized_at = System.os_time(:micro_seconds)
       params = unquote(params)
 
@@ -35,13 +37,15 @@ defmodule EventBus.EventSource do
             {params[:topic], result}
         end
 
+      time_spent = System.monotonic_time(:micro_seconds) - started_at
+
       %Event{
         id: params[:id],
         topic: topic,
         transaction_id: params[:transaction_id],
         data: data,
         initialized_at: initialized_at,
-        occurred_at: System.os_time(:micro_seconds),
+        occurred_at: initialized_at + time_spent,
         source: source,
         ttl: params[:ttl]
       }


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Depending on `System.os_time/1` for both `initialized_at` and `occurred_at` may give minus result when OS is busy. With this PR, the `occurred_at` field recalculated with the method `System.monotonic_time/1`.

### Changes

- [x] Update time spent calculation for EventSource block

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue: https://github.com/otobus/event_bus/issues/25
