### PR TITLE
Log empty topic listeners to prevent unnecessary ETS inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.X]
 
-
+- Log empty topic listeners
+- Add missing tests for existence check
 - Update time spent calculation for EventSource block
 - Remove support for system event tracing (Updated the wiki to create wrapper for system event tracing)
 

--- a/lib/event_bus/services/notification.ex
+++ b/lib/event_bus/services/notification.ex
@@ -11,10 +11,15 @@ defmodule EventBus.Service.Notification do
   @spec notify(Event.t()) :: no_return()
   def notify(%Event{id: id, topic: topic} = event) do
     listeners = Subscription.subscribers(topic)
-    :ok = Store.create(event)
-    :ok = Observation.create({listeners, topic, id})
 
-    notify_listeners(listeners, {topic, id})
+    if listeners == [] do
+      Logger.log(@logging_level, "Topic :#{topic} listener set is empty!")
+    else
+      :ok = Store.create(event)
+      :ok = Observation.create({listeners, topic, id})
+
+      notify_listeners(listeners, {topic, id})
+    end
   end
 
   @spec notify_listeners(list(), tuple()) :: no_return()

--- a/test/event_bus/managers/observation_test.exs
+++ b/test/event_bus/managers/observation_test.exs
@@ -15,6 +15,13 @@ defmodule EventBus.Manager.ObservationTest do
     :ok
   end
 
+  test "exist?" do
+    topic = :metrics_received_1
+    Observation.register_topic(topic)
+
+    assert Observation.exist?(topic)
+  end
+
   test "register_topic" do
     assert :ok == Observation.register_topic(:metrics_destroyed)
   end

--- a/test/event_bus/managers/store_test.exs
+++ b/test/event_bus/managers/store_test.exs
@@ -15,6 +15,13 @@ defmodule EventBus.Manager.StoreTest do
     :ok
   end
 
+  test "exist?" do
+    topic = :metrics_received_1
+    Store.register_topic(topic)
+
+    assert Store.exist?(topic)
+  end
+
   test "register_topic" do
     assert :ok == Store.register_topic(@topic)
   end

--- a/test/event_bus/managers/topic_test.exs
+++ b/test/event_bus/managers/topic_test.exs
@@ -13,6 +13,13 @@ defmodule EventBus.Manager.TopicTest do
     :ok
   end
 
+  test "exist?" do
+    topic = :metrics_received_1
+    Topic.register(topic)
+
+    assert Topic.exist?(topic)
+  end
+
   test "register_topic" do
     assert :ok == Topic.register(:t1)
   end


### PR DESCRIPTION
//cc @otobus

### Description

The current implementation allows all events to create insertion to Store and Observation ETS tables even if there is no subscriber for the topic. This may cause unnecessary operations. 

Fixes https://github.com/otobus/event_bus/issues/27

### Changes

- [x] Log these topics
- [x] Don't insert event data if there is no subscription for the event topic
- [x] Add missing tests for the existence check

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and of course a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue: https://github.com/otobus/event_bus/issues/27
