### PR TITLE
Introduce fetch_event_data function to fetch only event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.X]
 
+- Introduce `fetch_event_data` function to fetch only event data
 - Log empty topic listeners
 - Add missing tests for existence check
 - Update time spent calculation for EventSource block

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ topic = :bye_received
 id = "124"
 EventBus.fetch_event({topic, id})
 > %EventBus.Model.Event{data: [user_id: 1, goal: "exit"], id: "124", topic: :bye_received, transaction_id: "1"}
+
+# To fetch only the event data
+EventBus.fetch_event_data({topic, id})
+> data: [user_id: 1, goal: "exit"]
 ```
 
 ##### Mark as completed on Event Observation Manager

--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -180,17 +180,31 @@ defmodule EventBus do
     as: :subscribers
 
   @doc """
-  Fetch event data
+  Fetch event
 
   ## Examples
 
       EventBus.fetch_event({:hello_received, "123"})
+      %EventBus.Model.Model{}
 
   """
   @spec fetch_event({atom(), String.t() | integer()}) :: Event.t()
   defdelegate fetch_event(event_shadow),
     to: Store,
     as: :fetch
+
+  @doc """
+  Fetch event data
+
+  ## Examples
+
+      EventBus.fetch_event_data({:hello_received, "123"})
+
+  """
+  @spec fetch_event_data({atom(), String.t() | integer()}) :: any()
+  defdelegate fetch_event_data(event_shadow),
+    to: Store,
+    as: :fetch_data
 
   @doc """
   Send the event processing completed to the Observation Manager

--- a/lib/event_bus/managers/store.ex
+++ b/lib/event_bus/managers/store.ex
@@ -72,10 +72,18 @@ defmodule EventBus.Manager.Store do
   @doc """
   Fetch an event from the store
   """
-  @spec fetch({atom(), String.t() | integer()}) :: any()
+  @spec fetch({atom(), String.t() | integer()}) :: Event.t() | nil
   defdelegate fetch(event_shadow),
     to: @backend,
     as: :fetch
+
+  @doc """
+  Fetch an event's data from the store
+  """
+  @spec fetch_data({atom(), String.t() | integer()}) :: any()
+  defdelegate fetch_data(event_shadow),
+    to: @backend,
+    as: :fetch_data
 
   ###########################################################################
   # PRIVATE API

--- a/lib/event_bus/services/store.ex
+++ b/lib/event_bus/services/store.ex
@@ -28,12 +28,19 @@ defmodule EventBus.Service.Store do
   end
 
   @doc false
-  @spec fetch({atom(), String.t() | integer()}) :: any()
+  @spec fetch({atom(), String.t() | integer()}) :: Event.t() | nil
   def fetch({topic, id}) do
     case Ets.lookup(table_name(topic), id) do
       [{_, %Event{} = event}] -> event
       _ -> nil
     end
+  end
+
+  @doc false
+  @spec fetch_data({atom(), String.t() | integer()}) :: any()
+  def fetch_data({topic, id}) do
+    event = fetch({topic, id}) || %{}
+    Map.get(event, :data)
   end
 
   @doc false

--- a/test/event_bus/services/store_test.exs
+++ b/test/event_bus/services/store_test.exs
@@ -71,8 +71,24 @@ defmodule EventBus.Service.StoreTest do
     assert second_event == Store.fetch({topic, second_event.id})
   end
 
-  test "delete and fetch" do
+  test "fetch_data" do
     topic = :metrics_received_4
+    Store.register_topic(topic)
+
+    event = %Event{
+      id: "E1",
+      transaction_id: "T1",
+      data: ["Mustafa", "Turan"],
+      topic: topic
+    }
+
+    :ok = Store.create(event)
+
+    assert event.data == Store.fetch_data({topic, event.id})
+  end
+
+  test "delete and fetch" do
+    topic = :metrics_received_5
     Store.register_topic(topic)
 
     event = %Event{


### PR DESCRIPTION
//cc @otobus 

### Description
Introduce `fetch_event_data` function to fetch only event data

### Changes

- [x] Introduce `fetch_event_data` function to fetch only event data

### Is it ready?

- [NA] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit 
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version
