### PR TITLE
Allow optional vars from the configuration for event builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.X]
 
+- Delegate optional variables to optional library configuration when building/notifying events with Event builder
+- Add random id generator for Event builder
 - Introduce `fetch_event_data` function to fetch only event data
 - Log empty topic listeners
 - Add missing tests for existence check

--- a/README.md
+++ b/README.md
@@ -276,17 +276,30 @@ end
 > %EventBus.Model.Event{data: %{email: "jd@example.com", name: "John Doe"},
  id: "some unique id", initialized_at: 1515274599140491,
  occurred_at: 1515274599141211, source: "my event creator", topic: :user_created, transaction_id: "tx", ttl: 600000}
+```
 
+It is recommended to set optional params in event_bus application config, this will allow you to auto generate majority of optional values without writing code. Here is a sample config for event_bus:
 
+```elixir
+config :event_bus,
+  topics: [], # list of atoms
+  ttl: 30_000_000, # integer
+  time_unit: :micro_seconds, # atom
+  id_generator: EventBus.Util.String # module: must implement 'unique_id/0' function
+```
+
+After having such config like above, you can generate events without providing optional attributes like below:
+
+```elixir
 # Without optional params
-params = %{id: id, topic: topic}
+params = %{topic: topic}
 EventSource.build(params) do
   %{email: "jd@example.com", name: "John Doe"}
 end
 > %EventBus.Model.Event{data: %{email: "jd@example.com", name: "John Doe"},
- id: "some unique id", initialized_at: 1515274599140491,
- occurred_at: 1515274599141211, source: nil, topic: :user_created,
- transaction_id: nil, ttl: nil}
+ id: "Ewk7fL6Erv0vsW6S", initialized_at: 1515274599140491,
+ occurred_at: 1515274599141211, source: "AutoModuleName", topic: :user_created,
+ transaction_id: nil, ttl: 30_000_000}
 
 # With optional error topic param
 params = %{id: id, topic: topic, error_topic: :user_create_erred}
@@ -296,7 +309,7 @@ end
 > %EventBus.Model.Event{data: {:error, %{email: "Invalid format"}},
  id: "some unique id", initialized_at: 1515274599140491,
  occurred_at: 1515274599141211, source: nil, topic: :user_create_erred,
- transaction_id: nil, ttl: nil}
+ transaction_id: nil, ttl: 30_000_000}
 ```
 
 ##### Use block notifier to notify event data to given topic

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,7 @@
 use Mix.Config
 
 config :event_bus,
-  topics: [:metrics_received, :metrics_summed]
+  topics: [:metrics_received, :metrics_summed],
+  ttl: 30_000_000,
+  time_unit: :micro_seconds,
+  id_generator: EventBus.Util.String

--- a/lib/event_bus/utils/regex.ex
+++ b/lib/event_bus/utils/regex.ex
@@ -1,7 +1,6 @@
 defmodule EventBus.Util.Regex do
-  @moduledoc """
-  Regex util for event bus
-  """
+  @moduledoc false
+  # Regex util for event bus
 
   @doc """
   It checks if the given list of keys includes the key

--- a/lib/event_bus/utils/string.ex
+++ b/lib/event_bus/utils/string.ex
@@ -1,0 +1,12 @@
+defmodule EventBus.Util.String do
+  @moduledoc false
+  # String util for event bus
+
+  @doc """
+  Generates random id(Most probably unique id)
+  """
+  @spec unique_id() :: String.t()
+  def unique_id do
+    Base.url_encode64(:crypto.strong_rand_bytes(7), padding: false)
+  end
+end

--- a/test/event_bus/event_source_test.exs
+++ b/test/event_bus/event_source_test.exs
@@ -9,7 +9,7 @@ defmodule EventBus.EventSourceTest do
     :ok
   end
 
-  test "build with source" do
+  test "build with all params" do
     id = 1
     topic = :user_created
     data = %{id: 1, name: "me", email: "me@example.com"}
@@ -35,33 +35,37 @@ defmodule EventBus.EventSourceTest do
     assert event.source == "me"
     refute is_nil(event.initialized_at)
     refute is_nil(event.occurred_at)
+    assert Event.duration(event) > 0
   end
 
-  test "build without source" do
-    id = 1
+  test "build without passing source" do
     topic = :user_created
-    data = %{id: 1, name: "me", email: "me@example.com"}
-    transaction_id = "t1"
-    ttl = 100
-
     event =
-      EventSource.build %{
-        id: id,
-        topic: topic,
-        transaction_id: transaction_id,
-        ttl: ttl
-      } do
-        data
+      EventSource.build %{topic: topic} do
+        "some event data"
       end
 
-    assert event.data == data
-    assert event.id == id
-    assert event.topic == topic
-    assert event.transaction_id == transaction_id
-    assert event.ttl == ttl
     assert event.source == "EventBus.EventSourceTest"
-    refute is_nil(event.initialized_at)
-    refute is_nil(event.occurred_at)
+  end
+
+  test "build without passing ttl, sets the ttl from app configuration" do
+    topic = :user_created
+    event =
+      EventSource.build %{topic: topic} do
+        "some event data"
+      end
+
+    assert event.ttl == 30_000_000
+  end
+
+  test "build without passing id, sets the id with unique_id function" do
+    topic = :user_created
+    event =
+      EventSource.build %{topic: topic} do
+        "some event data"
+      end
+
+    refute is_nil(event.id)
   end
 
   test "build with error topic" do

--- a/test/event_bus/utils/regex_test.exs
+++ b/test/event_bus/utils/regex_test.exs
@@ -2,8 +2,6 @@ defmodule EventBus.Util.RegexTest do
   use ExUnit.Case
   alias EventBus.Util.Regex, as: RegexUtil
 
-  # doctest RegexUtil
-
   test "superset? should return true when it is superset of given key" do
     assert RegexUtil.superset?(~w(.*), "some")
     assert RegexUtil.superset?(~w(metrics painted), "metrics_received")

--- a/test/event_bus/utils/string_test.exs
+++ b/test/event_bus/utils/string_test.exs
@@ -1,0 +1,8 @@
+defmodule EventBus.Util.StringTest do
+  use ExUnit.Case
+  alias EventBus.Util.String, as: StringUtil
+
+  test "generates unique_id" do
+    refute StringUtil.unique_id() == StringUtil.unique_id()
+  end
+end


### PR DESCRIPTION
//cc @otobus 

### Description
Allow optional vars from the configuration for event builder

### Changes

- [x] Delegate optional vars to optional configurations when building event with the block
- [x] Remove doc for lib specific utils
- [x] Add random id generator

### Is it ready?

- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version
