### PR TITLE
Make module alias consistent with service module naming

### DIFF
--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -12,10 +12,10 @@ defmodule EventBus.EventSource do
 
       alias EventBus.EventSource
       alias EventBus.Model.Event
-      alias EventBus.Util.String, as: StringUtil
+      alias EventBus.Util.Base62
 
       @eb_app :event_bus
-      @eb_id_gen Application.get_env(@eb_app, :id_generator, StringUtil)
+      @eb_id_gen Application.get_env(@eb_app, :id_generator, Base62)
       @eb_source String.replace("#{__MODULE__}", "Elixir.", "")
       @eb_time_unit Application.get_env(@eb_app, :time_unit, :micro_seconds)
       @eb_ttl Application.get_env(@eb_app, :ttl)

--- a/lib/event_bus/managers/notification.ex
+++ b/lib/event_bus/managers/notification.ex
@@ -7,6 +7,7 @@ defmodule EventBus.Manager.Notification do
   ###########################################################################
 
   use GenServer
+
   alias EventBus.Model.Event
   alias EventBus.Service.Notification, as: NotificationService
 

--- a/lib/event_bus/managers/observation.ex
+++ b/lib/event_bus/managers/observation.ex
@@ -9,6 +9,7 @@ defmodule EventBus.Manager.Observation do
   ###########################################################################
 
   use GenServer
+
   alias EventBus.Service.Observation, as: ObservationService
 
   @backend ObservationService

--- a/lib/event_bus/managers/store.ex
+++ b/lib/event_bus/managers/store.ex
@@ -8,6 +8,7 @@ defmodule EventBus.Manager.Store do
   ###########################################################################
 
   use GenServer
+
   alias EventBus.Model.Event
   alias EventBus.Service.Store, as: StoreService
 

--- a/lib/event_bus/managers/subscription.ex
+++ b/lib/event_bus/managers/subscription.ex
@@ -6,6 +6,7 @@ defmodule EventBus.Manager.Subscription do
   ###########################################################################
 
   use GenServer
+
   alias EventBus.Service.Subscription, as: SubscriptionService
 
   @backend SubscriptionService

--- a/lib/event_bus/managers/topic.ex
+++ b/lib/event_bus/managers/topic.ex
@@ -6,6 +6,7 @@ defmodule EventBus.Manager.Topic do
   ###########################################################################
 
   use GenServer
+
   alias EventBus.Service.Topic, as: TopicService
 
   @backend TopicService

--- a/lib/event_bus/services/observation.ex
+++ b/lib/event_bus/services/observation.ex
@@ -1,7 +1,7 @@
 defmodule EventBus.Service.Observation do
   @moduledoc false
 
-  alias EventBus.Manager.Store
+  alias EventBus.Manager.Store, as: StoreManager
   alias :ets, as: Ets
 
   @ets_opts [
@@ -79,7 +79,7 @@ defmodule EventBus.Service.Observation do
 
   @spec delete_with_relations(tuple()) :: no_return()
   defp delete_with_relations({topic, id}) do
-    Store.delete({topic, id})
+    StoreManager.delete({topic, id})
     Ets.delete(table_name(topic), id)
   end
 

--- a/lib/event_bus/services/subscription.ex
+++ b/lib/event_bus/services/subscription.ex
@@ -1,7 +1,7 @@
 defmodule EventBus.Service.Subscription do
   @moduledoc false
 
-  alias EventBus.Manager.Topic
+  alias EventBus.Manager.Topic, as: TopicManager
   alias EventBus.Util.Regex, as: RegexUtil
 
   @app :event_bus
@@ -109,7 +109,7 @@ defmodule EventBus.Service.Subscription do
   end
 
   defp init_topic_map do
-    topics = Topic.all()
+    topics = TopicManager.all()
 
     topics
     |> Enum.map(fn topic -> {topic, []} end)

--- a/lib/event_bus/services/topic.ex
+++ b/lib/event_bus/services/topic.ex
@@ -1,11 +1,13 @@
 defmodule EventBus.Service.Topic do
   @moduledoc false
 
-  alias EventBus.Manager.{Observation, Store, Subscription}
+  alias EventBus.Manager.Observation, as: ObservationManager
+  alias EventBus.Manager.Store, as: StoreManager
+  alias EventBus.Manager.Subscription, as: SubscriptionManager
 
   @app :event_bus
   @namespace :topics
-  @modules [Store, Subscription, Observation]
+  @modules [StoreManager, SubscriptionManager, ObservationManager]
 
   @doc false
   @spec all() :: list(atom())

--- a/lib/event_bus/utils/string.ex
+++ b/lib/event_bus/utils/string.ex
@@ -1,6 +1,7 @@
 defmodule EventBus.Util.String do
   @moduledoc false
   # String util for event bus
+  # Warning: This module is deprecated will be removed in next major release
 
   alias EventBus.Util.Base62
 


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Make module alias consistent with service module naming

### Changes

- [x] Make module alias consistent with service module naming

### Is it ready?

- [x] The changes have only one commit
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Didn't bump the version

### References

- Issue: NA
