### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Data structure for `EventBus.Model.Event`
   initialized_at: integer(), # optional, might be seconds, milliseconds or microseconds even nanoseconds since Elixir does not have a limit on integer size
   occurred_at: integer(), # optional, might be seconds, milliseconds or microseconds even nanoseconds since Elixir does not have a limit on integer size
   source: String.t, # optional, source of the event, who created it
-  ttl: integer() # optional, might be seconds, milliseconds or microseconds even nanoseconds since Elixir does not have a limit on integer size. If `tll` field is set, it is recommended to set `occurred_at` field too.
+  ttl: integer() # optional, might be seconds, milliseconds or microseconds even nanoseconds since Elixir does not have a limit on integer size. If `ttl` field is set, it is recommended to set `occurred_at` field too.
 }
 ```
 


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Fix typo on README.

### Changes

- [ ] README updated section on `ttl`

### Is it ready?

- [ ] Created an issue and defined what the problem is
- [ ] Fixed the defined issue
- [ ] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [ ] The changes don't break current functionality
- [ ] All tests are covered and passing travis
- [ ] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [ ] Added specs and docs if a new function introduced
- [ ] Updated specs and docs if changed any params of a function
- [ ] Updated changelog
- [ ] Updated readme
- [ ] Didn't bump the version

### References

- Issue N/A
