### PR TITLE
Add public high-level types for each function to prevent misusage of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.X]
+
+- Add public types to main module to increase type safety and readability
+- Remove allowence of passing string on topic registration/deregistration
+- Allow passing `event_shadow` to `mark_as_completed/1` and `mark_as_skipped/1`
+
 ## [1.3.X]
 
 - Set default transaction to the id

--- a/lib/event_bus/managers/observation.ex
+++ b/lib/event_bus/managers/observation.ex
@@ -55,7 +55,11 @@ defmodule EventBus.Manager.Observation do
   """
   @spec mark_as_completed(tuple()) :: no_return()
   def mark_as_completed({listener, topic, id}) do
-    GenServer.cast(__MODULE__, {:mark_as_completed, {listener, topic, id}})
+    GenServer.cast(__MODULE__, {:mark_as_completed, {listener, {topic, id}}})
+  end
+
+  def mark_as_completed({listener, {topic, id}}) do
+    GenServer.cast(__MODULE__, {:mark_as_completed, {listener, {topic, id}}})
   end
 
   @doc """
@@ -63,14 +67,18 @@ defmodule EventBus.Manager.Observation do
   """
   @spec mark_as_skipped(tuple()) :: no_return()
   def mark_as_skipped({listener, topic, id}) do
-    GenServer.cast(__MODULE__, {:mark_as_skipped, {listener, topic, id}})
+    GenServer.cast(__MODULE__, {:mark_as_skipped, {listener, {topic, id}}})
+  end
+
+  def mark_as_skipped({listener, {topic, id}}) do
+    GenServer.cast(__MODULE__, {:mark_as_skipped, {listener, {topic, id}}})
   end
 
   @doc """
   Create an watcher
   """
   @spec create(tuple()) :: no_return()
-  def create({listeners, topic, id}) do
+  def create({listeners, {topic, id}}) do
     GenServer.call(__MODULE__, {:save, {topic, id}, {listeners, [], []}})
   end
 
@@ -122,15 +130,15 @@ defmodule EventBus.Manager.Observation do
 
   @doc false
   @spec handle_cast({:mark_as_completed, tuple()}, term()) :: no_return()
-  def handle_cast({:mark_as_completed, {listener, topic, id}}, state) do
-    @backend.mark_as_completed({listener, topic, id})
+  def handle_cast({:mark_as_completed, {listener, {topic, id}}}, state) do
+    @backend.mark_as_completed({listener, {topic, id}})
     {:noreply, state}
   end
 
   @doc false
   @spec handle_cast({:mark_as_skipped, tuple()}, term()) :: no_return()
-  def handle_cast({:mark_as_skipped, {listener, topic, id}}, state) do
-    @backend.mark_as_skipped({listener, topic, id})
+  def handle_cast({:mark_as_skipped, {listener, {topic, id}}}, state) do
+    @backend.mark_as_skipped({listener, {topic, id}})
     {:noreply, state}
   end
 end

--- a/lib/event_bus/managers/subscription.ex
+++ b/lib/event_bus/managers/subscription.ex
@@ -22,19 +22,19 @@ defmodule EventBus.Manager.Subscription do
   end
 
   @doc """
-  Subscribe the listener to topics
+  Does the listener subscribe to topic_patterns?
   """
-  @spec subscribed?({tuple() | module(), list()}) :: no_return()
-  def subscribed?({_listener, _topics} = subscriber) do
+  @spec subscribed?({tuple() | module(), list()}) :: boolean()
+  def subscribed?({_listener, _topic_patterns} = subscriber) do
     GenServer.call(__MODULE__, {:subscribed?, subscriber})
   end
 
   @doc """
-  Subscribe the listener to topics
+  Subscribe the listener to topic_patterns
   """
   @spec subscribe({tuple() | module(), list()}) :: no_return()
-  def subscribe({listener, topics}) do
-    GenServer.cast(__MODULE__, {:subscribe, {listener, topics}})
+  def subscribe({listener, topic_patterns}) do
+    GenServer.cast(__MODULE__, {:subscribe, {listener, topic_patterns}})
   end
 
   @doc """
@@ -94,8 +94,8 @@ defmodule EventBus.Manager.Subscription do
 
   @doc false
   @spec handle_cast({:subscribe, tuple()}, term()) :: no_return()
-  def handle_cast({:subscribe, {listener, topics}}, state) do
-    @backend.subscribe({listener, topics})
+  def handle_cast({:subscribe, {listener, topic_patterns}}, state) do
+    @backend.subscribe({listener, topic_patterns})
     {:noreply, state}
   end
 

--- a/lib/event_bus/managers/topic.ex
+++ b/lib/event_bus/managers/topic.ex
@@ -26,7 +26,7 @@ defmodule EventBus.Manager.Topic do
   It's important to keep this in blocking manner to prevent double creations in
   sub modules
   """
-  @spec exist?(String.t() | atom()) :: boolean()
+  @spec exist?(atom()) :: boolean()
   def exist?(topic) do
     GenServer.call(__MODULE__, {:exist?, topic})
   end
@@ -34,7 +34,7 @@ defmodule EventBus.Manager.Topic do
   @doc """
   Register a topic
   """
-  @spec register(String.t() | atom()) :: :ok
+  @spec register(atom()) :: :ok
   def register(topic) do
     GenServer.call(__MODULE__, {:register, topic})
   end
@@ -42,7 +42,7 @@ defmodule EventBus.Manager.Topic do
   @doc """
   Unregister a topic
   """
-  @spec unregister(String.t() | atom()) :: :ok
+  @spec unregister(atom()) :: :ok
   def unregister(topic) do
     GenServer.call(__MODULE__, {:unregister, topic})
   end
@@ -72,25 +72,24 @@ defmodule EventBus.Manager.Topic do
   ###########################################################################
 
   @doc false
-  @spec handle_call({:exist?, String.t() | atom()}, any(), term())
+  @spec handle_call({:exist?, atom()}, any(), term())
     :: {:reply, boolean(), term()}
   def handle_call({:exist?, topic}, _from, state) do
-    {:reply, @backend.exist?(:"#{topic}"), state}
+    {:reply, @backend.exist?(topic), state}
   end
 
   @doc false
-  @spec handle_call({:register, String.t() | atom()}, any(), term())
-    :: {:reply, :ok, term()}
+  @spec handle_call({:register, atom()}, any(), term()) :: {:reply, :ok, term()}
   def handle_call({:register, topic}, _from, state) do
-    @backend.register(:"#{topic}")
+    @backend.register(topic)
     {:reply, :ok, state}
   end
 
   @doc false
-  @spec handle_call({:unregister, String.t() | atom()}, any(), term())
+  @spec handle_call({:unregister, atom()}, any(), term())
     :: {:reply, :ok, term()}
   def handle_call({:unregister, topic}, _from, state) do
-    @backend.unregister(:"#{topic}")
+    @backend.unregister(topic)
     {:reply, :ok, state}
   end
 end

--- a/lib/event_bus/services/notification.ex
+++ b/lib/event_bus/services/notification.ex
@@ -17,7 +17,7 @@ defmodule EventBus.Service.Notification do
       warn_missing_topic_subscription(topic)
     else
       :ok = StoreManager.create(event)
-      :ok = ObservationManager.create({listeners, topic, id})
+      :ok = ObservationManager.create({listeners, {topic, id}})
 
       notify_listeners(listeners, {topic, id})
     end
@@ -34,7 +34,7 @@ defmodule EventBus.Service.Notification do
   rescue
     error ->
       log_error(listener, error)
-      ObservationManager.mark_as_skipped({{listener, config}, topic, id})
+      ObservationManager.mark_as_skipped({{listener, config}, {topic, id}})
   end
 
   @spec notify_listener(module(), tuple()) :: no_return()
@@ -43,7 +43,7 @@ defmodule EventBus.Service.Notification do
   rescue
     error ->
       log_error(listener, error)
-      ObservationManager.mark_as_skipped({listener, topic, id})
+      ObservationManager.mark_as_skipped({listener, {topic, id}})
   end
 
   @spec registration_status(atom()) :: String.t()

--- a/lib/event_bus/services/observation.ex
+++ b/lib/event_bus/services/observation.ex
@@ -35,16 +35,16 @@ defmodule EventBus.Service.Observation do
 
   @doc false
   @spec mark_as_completed(tuple()) :: no_return()
-  def mark_as_completed({listener, topic, id}) do
-    {listeners, completers, skippers} = fetch({topic, id})
-    save_or_delete({topic, id}, {listeners, [listener | completers], skippers})
+  def mark_as_completed({listener, event_shadow}) do
+    {listeners, completers, skippers} = fetch(event_shadow)
+    save_or_delete(event_shadow, {listeners, [listener | completers], skippers})
   end
 
   @doc false
   @spec mark_as_skipped(tuple()) :: no_return()
-  def mark_as_skipped({listener, topic, id}) do
-    {listeners, completers, skippers} = fetch({topic, id})
-    save_or_delete({topic, id}, {listeners, completers, [listener | skippers]})
+  def mark_as_skipped({listener, event_shadow}) do
+    {listeners, completers, skippers} = fetch(event_shadow)
+    save_or_delete(event_shadow, {listeners, completers, [listener | skippers]})
   end
 
   @doc false

--- a/test/event_bus/managers/observation_test.exs
+++ b/test/event_bus/managers/observation_test.exs
@@ -46,7 +46,7 @@ defmodule EventBus.Manager.ObservationTest do
 
     Observation.register_topic(topic)
 
-    assert :ok == Observation.create({listeners, topic, id})
+    assert :ok == Observation.create({listeners, {topic, id}})
   end
 
   test "complete" do
@@ -61,11 +61,16 @@ defmodule EventBus.Manager.ObservationTest do
     ]
 
     Observation.register_topic(topic)
-    Observation.create({listeners, topic, id})
+    Observation.create({listeners, {topic, id}})
 
     listener = {InputLogger, %{}}
+    another_listener = {Calculator, %{}}
 
-    assert :ok === Observation.mark_as_completed({listener, topic, id})
+    # with event_shadow tuple
+    assert :ok === Observation.mark_as_completed({listener, {topic, id}})
+
+    # with open tuple
+    assert :ok === Observation.mark_as_completed({another_listener, topic, id})
   end
 
   test "skip" do
@@ -80,7 +85,15 @@ defmodule EventBus.Manager.ObservationTest do
     ]
 
     Observation.register_topic(topic)
-    Observation.create({listeners, topic, id})
-    assert :ok == Observation.mark_as_skipped({{InputLogger, %{}}, topic, id})
+    Observation.create({listeners, {topic, id}})
+
+    listener = {InputLogger, %{}}
+    another_listener = {Calculator, %{}}
+
+    # with event_shadow tuple
+    assert :ok == Observation.mark_as_skipped({listener, {topic, id}})
+
+    # with open tuple
+    assert :ok == Observation.mark_as_skipped({another_listener, topic, id})
   end
 end

--- a/test/event_bus/services/observation_test.exs
+++ b/test/event_bus/services/observation_test.exs
@@ -74,7 +74,7 @@ defmodule EventBus.Service.ObservationTest do
 
     Observation.register_topic(topic)
     Observation.save({topic, id}, {listeners, [], []})
-    Observation.mark_as_completed({{InputLogger, %{}}, topic, id})
+    Observation.mark_as_completed({{InputLogger, %{}}, {topic, id}})
 
     assert {listeners, [{InputLogger, %{}}], []} == Observation.fetch({topic, id})
   end
@@ -92,7 +92,7 @@ defmodule EventBus.Service.ObservationTest do
 
     Observation.register_topic(topic)
     Observation.save({topic, id}, {listeners, [], []})
-    Observation.mark_as_skipped({{InputLogger, %{}}, topic, id})
+    Observation.mark_as_skipped({{InputLogger, %{}}, {topic, id}})
 
     assert {listeners, [], [{InputLogger, %{}}]} == Observation.fetch({topic, id})
   end


### PR DESCRIPTION
//cc @otobus

### Description
Enhancements for type safety, type docs, docs and internal function arities

### Changes

- [x] Add public high-level types for each function to prevent misusage of functions.
- [x] Remove string type support on topic name registrations and deregistration
- [x] Allow event_shadow as tuple on `mark_as_completed/1` and `mark_as_skipped/1`

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue https://github.com/otobus/event_bus/issues/46
