### PR TITLE
Fix spec for unsubscribe/1. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add public types to main module to increase type safety and readability
 - Remove allowence of passing string on topic registration/deregistration
 - Allow passing `event_shadow` to `mark_as_completed/1` and `mark_as_skipped/1`
+- Update wrong spec for unsubscribe/1
+- Add more test for unsubscribe/1
 
 ## [1.3.X]
 

--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -23,16 +23,16 @@ defmodule EventBus do
   @typedoc "Tuple of topic name and event id"
   @type event_shadow :: {topic(), event_id()}
 
-  @typedoc "Event listener/subscriber/consumer"
-  @type listener :: {listener_without_config() | listener_with_config()}
+  @typedoc "Event listener"
+  @type listener :: listener_without_config() | listener_with_config()
 
   @typedoc "Listener configuration"
   @type listener_config :: any()
 
-  @typedoc "List of event listeners/subscribers/consumers"
+  @typedoc "List of event listeners"
   @type listener_list :: list(listener())
 
-  @typedoc "Event listener/subscriber/consumer with config"
+  @typedoc "Event listener with config"
   @type listener_with_config :: {module(), listener_config()}
 
   @typedoc "Tuple of listener and event reference"
@@ -48,7 +48,7 @@ defmodule EventBus do
   @typedoc "Tuple of listener and list of topic patterns"
   @type listener_with_topic_patterns :: {listener(), topic_pattern_list()}
 
-  @typedoc "Event listener/subscriber/consumer without config"
+  @typedoc "Event listener without config"
   @type listener_without_config :: module()
 
   @typedoc "Topic name"

--- a/lib/event_bus/managers/subscription.ex
+++ b/lib/event_bus/managers/subscription.ex
@@ -40,7 +40,7 @@ defmodule EventBus.Manager.Subscription do
   @doc """
   Unsubscribe the listener
   """
-  @spec unsubscribe({tuple() | module()}) :: no_return()
+  @spec unsubscribe(tuple() | module()) :: no_return()
   def unsubscribe(listener) do
     GenServer.cast(__MODULE__, {:unsubscribe, listener})
   end

--- a/test/event_bus/managers/subscription_test.exs
+++ b/test/event_bus/managers/subscription_test.exs
@@ -26,7 +26,10 @@ defmodule EventBus.Manager.SubscriptionTest do
 
   test "subscribe" do
     assert :ok == Subscription.subscribe({{InputLogger, %{}}, [".*"]})
+    assert Subscription.subscribed?({{InputLogger, %{}}, [".*"]})
+
     assert :ok == Subscription.subscribe({AnotherCalculator, [".*"]})
+    assert Subscription.subscribed?({AnotherCalculator, [".*"]})
   end
 
   test "unsubscribe" do
@@ -34,7 +37,10 @@ defmodule EventBus.Manager.SubscriptionTest do
     Subscription.subscribe({AnotherCalculator, [".*"]})
 
     assert :ok == Subscription.unsubscribe({InputLogger, %{}})
+    refute Subscription.subscribed?({{InputLogger, %{}}, [".*"]})
+
     assert :ok == Subscription.unsubscribe(AnotherCalculator)
+    refute Subscription.subscribed?({AnotherCalculator, [".*"]})
   end
 
   test "register_topic" do


### PR DESCRIPTION
//cc @otobus 

### Description
Fix spec for `EventBus.unsubscribe/1`. 

### Changes

- [x] Fix spec for unsubscribe/1.  
- [x] Add more tests to unsubscribe/1

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Didn't bump the version

### References

- Issue https://github.com/otobus/event_bus/issues/48
