### PR TITLE
Fix default @eb_time_unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update wrong spec for unsubscribe/1
 - Add more test for unsubscribe/1
 - Add questions section
+- Change default `@eb_tme_unit` to `:microsecond`
 
 ## [1.3.X]
 
@@ -77,4 +78,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add `initialized_at` attribute
-

--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -17,7 +17,7 @@ defmodule EventBus.EventSource do
       @eb_app :event_bus
       @eb_id_gen Application.get_env(@eb_app, :id_generator, Base62)
       @eb_source String.replace("#{__MODULE__}", "Elixir.", "")
-      @eb_time_unit Application.get_env(@eb_app, :time_unit, :micro_seconds)
+      @eb_time_unit Application.get_env(@eb_app, :time_unit, :microsecond)
       @eb_ttl Application.get_env(@eb_app, :ttl)
     end
   end


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
The typespec for `time_unit()` actually defines the atom as `:microseconds`, which causes the code as-is to raise Dialyzer errors: https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/system.ex#L65

### Changes

- [x] Change default @eb_time_unit to `:microsecond`

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue #52 
