### PR TITLE
Normalize time units as their singular, non-underscored versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add more test for unsubscribe/1
 - Add questions section
 - Change default `@eb_tme_unit` to `:microsecond`
+- Change all instances of `micro_seconds` and `microseconds` to `microsecond`, as per Erlang 19+
 
 ## [1.3.X]
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ It is recommended to set optional params in event_bus application config, this w
 config :event_bus,
   topics: [], # list of atoms
   ttl: 30_000_000, # integer
-  time_unit: :micro_seconds, # atom
+  time_unit: :microsecond, # atom
   id_generator: EventBus.Util.Base62 # module: must implement 'unique_id/0' function
 ```
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :event_bus,
   topics: [:metrics_received, :metrics_summed],
   ttl: 30_000_000,
-  time_unit: :micro_seconds,
+  time_unit: :microsecond,
   id_generator: EventBus.Util.String

--- a/lib/event_bus/utils/base62.ex
+++ b/lib/event_bus/utils/base62.ex
@@ -33,9 +33,9 @@ defmodule EventBus.Util.Base62 do
     |> String.pad_leading(size, "0")
   end
 
-  # Current time (microseconds) encoded in base62
+  # Current time (microsecond) encoded in base62
   defp now do
-    encode(System.os_time(:microseconds))
+    encode(System.os_time(:microsecond))
   end
 
   # Assigns a random node_id on first call

--- a/test/event_bus/models/event_test.exs
+++ b/test/event_bus/models/event_test.exs
@@ -11,7 +11,7 @@ defmodule EventBus.Model.EventTest do
   end
 
   test "duration" do
-    initialized_at = System.os_time(:micro_seconds)
+    initialized_at = System.os_time(:microsecond)
     # do sth in this frame
     Process.sleep(1)
 
@@ -20,7 +20,7 @@ defmodule EventBus.Model.EventTest do
       topic: "user_created",
       data: %{id: 1, name: "me", email: "me@example.com"},
       initialized_at: initialized_at,
-      occurred_at: System.os_time(:micro_seconds)
+      occurred_at: System.os_time(:microsecond)
     }
 
     assert Event.duration(event) > 0


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Normalize time units as their singular, non-underscored versions.

This is in line with the new standards in Erlang 19+

### Changes

- [x] Changed all instances of `:micro_seconds` to `:microsecond
- [x] Changed all instances of `:microseconds` to `:microsecond`

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version

### References

- Issue #54
