### PR TITLE
Fix Elixir 1.7 warnings for string to atom conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.4.X]
+## [1.5.X]
+- Fix Elixir 1.7 warnings for string to atom conversions
+
+## [1.4.X] 2018.09.07
 
 - Add public types to main module to increase type safety and readability
 - Remove allowence of passing string on topic registration/deregistration
@@ -17,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix dialyzer warnings
 - Update the id generator source in test configuration
 
-## [1.3.X]
+## [1.3.X] 2018.08.04
 
 - Set default transaction to the id
 - Delegate optional variables to optional library configuration when building/notifying events with Event builder

--- a/lib/event_bus/services/observation.ex
+++ b/lib/event_bus/services/observation.ex
@@ -84,7 +84,7 @@ defmodule EventBus.Service.Observation do
   end
 
   @spec table_name(atom()) :: atom()
-  defp table_name(name) do
-    :"#{@prefix}#{name}"
+  defp table_name(topic) do
+    String.to_atom("#{@prefix}#{topic}")
   end
 end

--- a/lib/event_bus/services/store.ex
+++ b/lib/event_bus/services/store.ex
@@ -57,6 +57,6 @@ defmodule EventBus.Service.Store do
   end
 
   defp table_name(topic) do
-    :"#{@prefix}#{topic}"
+    String.to_atom("#{@prefix}#{topic}")
   end
 end

--- a/test/event_bus/services/observation_test.exs
+++ b/test/event_bus/services/observation_test.exs
@@ -31,8 +31,9 @@ defmodule EventBus.Service.ObservationTest do
     topic = :metrics_destroyed
     Observation.register_topic(topic)
     all_tables = :ets.all()
+    table_name = String.to_atom("eb_ew_#{topic}")
 
-    assert Enum.any?(all_tables, fn t -> t == :"eb_ew_#{topic}" end)
+    assert Enum.any?(all_tables, fn t -> t == table_name end)
   end
 
   test "unregister_topic" do
@@ -40,8 +41,9 @@ defmodule EventBus.Service.ObservationTest do
     Observation.register_topic(topic)
     Observation.unregister_topic(topic)
     all_tables = :ets.all()
+    table_name = String.to_atom("eb_ew_#{topic}")
 
-    refute Enum.any?(all_tables, fn t -> t == :"eb_ew_#{topic}" end)
+    refute Enum.any?(all_tables, fn t -> t == table_name end)
   end
 
   test "create and fetch" do

--- a/test/event_bus/services/store_test.exs
+++ b/test/event_bus/services/store_test.exs
@@ -20,16 +20,18 @@ defmodule EventBus.Service.StoreTest do
     topic = :metrics_received_1
     Store.register_topic(topic)
     all_tables = :ets.all()
+    table_name = String.to_atom("eb_es_#{topic}")
 
-    assert Enum.any?(all_tables, fn t -> t == :"eb_es_#{topic}" end)
+    assert Enum.any?(all_tables, fn t -> t == table_name end)
   end
 
   test "unregister_topic" do
     topic = :metrics_received_1
     Store.unregister_topic(topic)
     all_tables = :ets.all()
+    table_name = String.to_atom("eb_es_#{topic}")
 
-    refute Enum.any?(all_tables, fn t -> t == :"eb_es_#{topic}" end)
+    refute Enum.any?(all_tables, fn t -> t == table_name end)
   end
 
   test "create" do

--- a/test/event_bus/services/topic_test.exs
+++ b/test/event_bus/services/topic_test.exs
@@ -25,9 +25,12 @@ defmodule EventBus.Service.TopicTest do
     Topic.register(topic)
     all_tables = :ets.all()
 
+    store_table_name = String.to_atom("eb_es_#{topic}")
+    watcher_table_name = String.to_atom("eb_ew_#{topic}")
+
     assert Enum.any?(Topic.all(), fn t -> t == topic end)
-    assert Enum.any?(all_tables, fn t -> t == :"eb_es_#{topic}" end)
-    assert Enum.any?(all_tables, fn t -> t == :"eb_ew_#{topic}" end)
+    assert Enum.any?(all_tables, fn t -> t == store_table_name end)
+    assert Enum.any?(all_tables, fn t -> t == watcher_table_name end)
   end
 
   test "register_topic does not re-register same topic" do
@@ -45,9 +48,12 @@ defmodule EventBus.Service.TopicTest do
     Topic.unregister(topic)
     all_tables = :ets.all()
 
+    store_table_name = String.to_atom("eb_es_#{topic}")
+    watcher_table_name = String.to_atom("eb_ew_#{topic}")
+
     refute Enum.any?(Topic.all(), fn t -> t == topic end)
-    refute Enum.any?(all_tables, fn t -> t == :"eb_es_#{topic}" end)
-    refute Enum.any?(all_tables, fn t -> t == :"eb_ew_#{topic}" end)
+    refute Enum.any?(all_tables, fn t -> t == store_table_name end)
+    refute Enum.any?(all_tables, fn t -> t == watcher_table_name end)
   end
 
   test "all" do


### PR DESCRIPTION
//cc @otobus 

### Description
Fix Elixir 1.7 warnings for String to Atom conversions

### Changes

- [x] Fix Elixir 1.7 warnings for String to Atom conversions

### Is it ready?

- [x] The changes have only one commit
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [x] Updated readme
- [x] Didn't bump the version