### PR TITLE
do not use case but functions to handle yield result.

### DIFF
--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -33,14 +33,7 @@ defmodule EventBus.EventSource do
       initialized_at = MonotonicTime.now()
       params = unquote(params)
 
-      {topic, data} =
-        case unquote(yield) do
-          {:error, error} ->
-            {params[:error_topic] || params[:topic], {:error, error}}
-
-          result ->
-            {params[:topic], result}
-        end
+      {topic, data} = unquote(yield) |> EventSource.handle_yield_result(params)
 
       id = Map.get(params, :id, @eb_id_gen.unique_id())
 
@@ -73,5 +66,16 @@ defmodule EventBus.EventSource do
       EventBus.notify(event)
       event.data
     end
+  end
+
+  # Handles the yield execution results
+  @doc false
+  def handle_yield_result({:error, error}, params) do
+    {params[:error_topic] || params[:topic], {:error, error}}
+  end
+
+  @doc false
+  def handle_yield_result(result, params) do
+    {params[:topic], result}
   end
 end


### PR DESCRIPTION
In this way is possible to handle setups where notify/build function never returns an error, which result into dialyzer warnings, as discussed in #69 

//cc @otobus @mustafaturan 

### Description
On some usage scenarios (for example building up a map from other variables in the yield block) errors cannot simply happen, but the current implementation forces the user to always have the success and error paths in the yield block. 
Basically, during the macro expansion, the user provided yield block is always case-matched with two conditions, but if the block does not a path to error, dialyzer will warn about that.

### Changes

- [x] Delegate the `{topic, data}` building to separate functions in order to avoid case-matching dead paths

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit 
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Didn't bump the version

### References

- Issue #69 
