### PR TITLE
Pass a function instead of a code block to EventSource macros

### DIFF
--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -2,10 +2,7 @@ defmodule EventBus.EventSource do
   @moduledoc """
   Event builder and notifier blocks/yields for EventBus
   """
-
-  alias EventBus.Model.Event
-  alias EventBus.Util.MonotonicTime
-  alias __MODULE__
+  alias EventBus.EventSourceImpl
 
   defmacro __using__(_) do
     quote do
@@ -13,12 +10,6 @@ defmodule EventBus.EventSource do
 
       alias EventBus.EventSource
       alias EventBus.Model.Event
-      alias EventBus.Util.Base62
-
-      @eb_app :event_bus
-      @eb_id_gen Application.get_env(@eb_app, :id_generator, Base62)
-      @eb_source String.replace("#{__MODULE__}", "Elixir.", "")
-      @eb_ttl Application.get_env(@eb_app, :ttl)
     end
   end
 
@@ -28,32 +19,13 @@ defmodule EventBus.EventSource do
   It auto sets id, transaction_id, source, ttl, initialized_at and occurred_at
   fields when they are not provided in the params
   """
-  defmacro build(params, do: yield) do
+  defmacro build(params, fun) do
+    macro_build(Macro.escape(__CALLER__), params, fun)
+  end
+
+  defp macro_build(caller, params, fun) do
     quote do
-      initialized_at = MonotonicTime.now()
-      params = unquote(params)
-
-      {topic, data} =
-        case unquote(yield) do
-          {:error, error} ->
-            {params[:error_topic] || params[:topic], {:error, error}}
-
-          result ->
-            {params[:topic], result}
-        end
-
-      id = Map.get(params, :id, @eb_id_gen.unique_id())
-
-      %Event{
-        id: id,
-        topic: topic,
-        transaction_id: Map.get(params, :transaction_id, id),
-        data: data,
-        initialized_at: initialized_at,
-        occurred_at: MonotonicTime.now(),
-        source: Map.get(params, :source, @eb_source),
-        ttl: Map.get(params, :ttl, @eb_ttl)
-      }
+      EventSourceImpl.build(unquote(caller), unquote(params), unquote(fun))
     end
   end
 
@@ -63,15 +35,70 @@ defmodule EventBus.EventSource do
   It auto sets id, transaction_id, source, ttl, initialized_at and occurred_at
   fields when they are not provided in the params
   """
-  defmacro notify(params, do: yield) do
-    quote do
-      event =
-        EventSource.build unquote(params) do
-          unquote(yield)
-        end
+  defmacro notify(params, fun) do
+    macro_notify(Macro.escape(__CALLER__), params, fun)
+  end
 
-      EventBus.notify(event)
-      event.data
+  defp macro_notify(caller, params, fun) do
+    quote do
+      EventSourceImpl.notify(unquote(caller), unquote(params), unquote(fun))
     end
+  end
+end
+
+defmodule EventBus.EventSourceImpl do
+  @moduledoc false
+  alias EventBus.Model.Event
+  alias EventBus.Util.Base62
+  alias EventBus.Util.MonotonicTime
+
+  @eb_app :event_bus
+
+  @doc false
+  def build(caller, params, fun) do
+    initialized_at = MonotonicTime.now()
+    config = get_config(caller)
+
+    {topic, data} =
+      case fun.() do
+        {:error, error} ->
+          {params[:error_topic] || params[:topic], {:error, error}}
+
+        result ->
+          {params[:topic], result}
+      end
+
+    id_generator = Map.get(config, :eb_id_gen)
+    id = Map.get(params, :id, id_generator.unique_id())
+
+    %Event{
+      id: id,
+      topic: topic,
+      transaction_id: Map.get(params, :transaction_id, id),
+      data: data,
+      initialized_at: initialized_at,
+      occurred_at: MonotonicTime.now(),
+      source: Map.get(params, :source, config[:eb_source]),
+      ttl: Map.get(params, :ttl, config[:eb_ttl])
+    }
+  end
+
+  @doc false
+  def notify(caller, params, fun) do
+    event = build(caller, params, fun)
+    EventBus.notify(event)
+
+    event.data
+  end
+
+  defp get_config(caller) do
+    %{module: module, function: _fun, file: _file, line: _line} = caller
+
+    %{
+      eb_app: @eb_app,
+      eb_id_gen: Application.get_env(@eb_app, :id_generator, Base62),
+      eb_source: String.replace("#{module}", "Elixir.", ""),
+      eb_ttl: Application.get_env(@eb_app, :ttl)
+    }
   end
 end

--- a/test/event_bus/event_source_test.exs
+++ b/test/event_bus/event_source_test.exs
@@ -15,6 +15,7 @@ defmodule EventBus.EventSourceTest do
     data = %{id: 1, name: "me", email: "me@example.com"}
     transaction_id = "t1"
     ttl = 100
+
     params = %{
       id: id,
       topic: topic,
@@ -24,10 +25,10 @@ defmodule EventBus.EventSourceTest do
     }
 
     event =
-      EventSource.build params do
+      EventSource.build(params, fn ->
         Process.sleep(1_000)
         data
-      end
+      end)
 
     assert event.data == data
     assert event.id == id
@@ -42,30 +43,33 @@ defmodule EventBus.EventSourceTest do
 
   test "build without passing source" do
     topic = :user_created
+
     event =
-      EventSource.build %{topic: topic} do
+      EventSource.build(%{topic: topic}, fn ->
         "some event data"
-      end
+      end)
 
     assert event.source == "EventBus.EventSourceTest"
   end
 
   test "build without passing ttl, sets the ttl from app configuration" do
     topic = :user_created
+
     event =
-      EventSource.build %{topic: topic} do
+      EventSource.build(%{topic: topic}, fn ->
         "some event data"
-      end
+      end)
 
     assert event.ttl == 30_000_000
   end
 
   test "build without passing id, sets the id with unique_id function" do
     topic = :user_created
+
     event =
-      EventSource.build %{topic: topic} do
+      EventSource.build(%{topic: topic}, fn ->
         "some event data"
-      end
+      end)
 
     refute is_nil(event.id)
   end
@@ -79,15 +83,18 @@ defmodule EventBus.EventSourceTest do
     ttl = 100
 
     event =
-      EventSource.build %{
-        id: id,
-        topic: topic,
-        transaction_id: transaction_id,
-        ttl: ttl,
-        error_topic: error_topic
-      } do
-        {:error, data}
-      end
+      EventSource.build(
+        %{
+          id: id,
+          topic: topic,
+          transaction_id: transaction_id,
+          ttl: ttl,
+          error_topic: error_topic
+        },
+        fn ->
+          {:error, data}
+        end
+      )
 
     assert event.data == {:error, data}
     assert event.id == id
@@ -105,9 +112,9 @@ defmodule EventBus.EventSourceTest do
     data = %{id: 1, name: "me", email: "me@example.com"}
 
     result =
-      EventSource.notify %{id: id, topic: topic} do
+      EventSource.notify(%{id: id, topic: topic}, fn ->
         data
-      end
+      end)
 
     assert result == data
   end


### PR DESCRIPTION
Note: this PR conflicts with https://github.com/otobus/event_bus/pull/70
Note: this PR breaks current API for `EventSource`

Also, reduce macro size by delegating implementation to a private module.

Unfortunately, macros cannot be removed completely because we still need to get the caller in order to complete the event with source. As a side effect, now we have function, file and line available, so will be possible to expand the event source information in the future.

//cc @otobus @mustafaturan

### Description
Following the principle to avoid macros when possible :) and make them as small as possible, the `EventSource` macros have been reduce to what is really needed. All the logic moved to a separate, private module. The macro cannot be removed since we need to get the `__CALLER__` information to enrich the `Event`.

Also, pass a function instead of a code block. Mainly because is a more functional way pass code around, and inline with all Elixir APIs (and Ecto, and so on). There's no real need to pass a code block. I think that passing a code block with do/end is more suitable for a DSL or basic functions like unless/do.

This also fixes #69 

### Changes

- [x] Pass a function instead of a code block
- [x] Minimize macros size by delegating to a private implementation module

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit 
- [ ] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [ ] Added specs and docs if a new function introduced
- [ ] Updated specs and docs if changed any params of a function
- [ ] Updated changelog
- [ ] Updated readme
- [ ] Didn't bump the version -> This should be updated, since API have changed

### References

- Issue #71, #69 
