### PR TITLE
Add Elixir 1.8 and OTP 21.0 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ elixir:
   - 1.5
   - 1.6
   - 1.7
+  - 1.8
 otp_release:
   - 20.0
 matrix:
   include:
     - elixir: 1.7
+      otp_release: 21.0
+    - elixir: 1.8
       otp_release: 21.0
 env:
   - MIX_ENV=test


### PR DESCRIPTION
//cc @otobus

### Description
Add Elixir 1.8 and OTP 21.0 to Travis config

### Changes

- [x] Add Elixir 1.8 to Travis config 
- [x] Add OTP 21.0 to Travis config

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit 
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Didn't bump the version

### References

- Issue: https://github.com/otobus/event_bus/issues/89
