### PR TITLE
Update travis to include elixir 1.9 and otp 22 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ elixir:
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
 otp_release:
   - 20.0
 matrix:
@@ -12,6 +13,12 @@ matrix:
       otp_release: 21.0
     - elixir: 1.8
       otp_release: 21.0
+    - elixir: 1.8
+      otp_release: 22.0
+    - elixir: 1.9
+      otp_release: 21.0
+    - elixir: 1.9
+      otp_release: 22.0
 env:
   - MIX_ENV=test
 script:


### PR DESCRIPTION
//cc @otobus 

### Description
Update travis to include elixir `1.9` and otp `22` versions

### Changes

- [x] Update travis to include elixir `1.9` and otp `22` versions
