### PR TITLE
[fix] `Store.fetch` should safely handle missing ETS data and improve test stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - - Include credo checks
 - Update `EventBus.Model.Event` struct optional attribute type specs to allow `nil` values
 - Update license year
+- Change `EventBus.Service.Store.fetch` to return a safe value when ETS data is missing and log it
 
 ## [1.5.X] 2018.09.27
 

--- a/lib/event_bus/services/observation.ex
+++ b/lib/event_bus/services/observation.ex
@@ -1,6 +1,8 @@
 defmodule EventBus.Service.Observation do
   @moduledoc false
 
+  require Logger
+
   alias EventBus.Manager.Store, as: StoreManager
   alias :ets, as: Ets
 
@@ -44,23 +46,34 @@ defmodule EventBus.Service.Observation do
   @doc false
   @spec mark_as_completed(subscriber_with_event_ref()) :: :ok
   def mark_as_completed({subscriber, event_shadow}) do
-    {subscribers, completers, skippers} = fetch(event_shadow)
-    save_or_delete(event_shadow, {subscribers, [subscriber | completers], skippers})
+    case fetch(event_shadow) do
+      {subscribers, completers, skippers} ->
+        save_or_delete(event_shadow, {subscribers, [subscriber | completers], skippers})
+        nil -> :ok
+    end
   end
 
   @doc false
   @spec mark_as_skipped(subscriber_with_event_ref()) :: :ok
   def mark_as_skipped({subscriber, event_shadow}) do
-    {subscribers, completers, skippers} = fetch(event_shadow)
-    save_or_delete(event_shadow, {subscribers, completers, [subscriber | skippers]})
+    case fetch(event_shadow) do
+      {subscribers, completers, skippers} ->
+        save_or_delete(event_shadow, {subscribers, completers, [subscriber | skippers]})
+      nil -> :ok
+    end
   end
 
   @doc false
-  @spec fetch(event_shadow()) :: any()
+  @spec fetch(event_shadow()) :: {subscribers(), subscribers(), subscribers()} | nil
   def fetch({topic, id}) do
     case Ets.lookup(table_name(topic), id) do
       [{_, data}] -> data
-      _ -> nil
+      _ ->
+        Logger.log(:info, fn ->
+          "[EVENTBUS][OBSERVATION]\s#{topic}.#{id}.ets_fetch_error"
+        end)
+
+        nil
     end
   end
 

--- a/lib/event_bus/services/store.ex
+++ b/lib/event_bus/services/store.ex
@@ -1,6 +1,8 @@
 defmodule EventBus.Service.Store do
   @moduledoc false
 
+  require Logger
+
   alias EventBus.Model.Event
   alias :ets, as: Ets
 
@@ -38,7 +40,12 @@ defmodule EventBus.Service.Store do
   def fetch({topic, id}) do
     case Ets.lookup(table_name(topic), id) do
       [{_, %Event{} = event}] -> event
-      _ -> nil
+      _ ->
+        Logger.log(:info, fn ->
+          "[EVENTBUS][STORE]\s#{topic}.#{id}.ets_fetch_error"
+        end)
+
+        nil
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -16,7 +16,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
This safely handles `Store.fetch` when ETS data is missing for some reason in production that avoids  crashing the application.

//cc @otobus @mustafaturan

### Description
This safely handles `Store.fetch` when ETS data is missing for some reason in production that avoids  crashing the application.

Also made the helper subscribers be `GenServer` to notify the test process that the event was processed. It also helps `event_bus_test.exs` to correctly capture the log for the test to pass.

### Changes

- [x] `Store.fetch` returns `{[], [], []}` when ETS row is empty 
- [x] Improve test stability for `event_bus_test.exs`

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and of course a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [ ] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [x] Added specs and docs if a new function introduced
- [x] Updated specs and docs if changed any params of a function
- [x] Updated changelog
- [ ] Updated readme
- [x] Didn't bump the version

### References

- Issue #113 
