### PR TITLE
Add :crypto to extra_applications to fix warnings when `mix deps.compile`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule EventBus.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger], mod: {EventBus.Application, []}]
+    [extra_applications: [:logger, :crypto], mod: {EventBus.Application, []}]
   end
 
   defp elixirc_paths(:test) do


### PR DESCRIPTION
//cc @otobus @mustafaturan

**Describe the bug**
Compiler warnings about :crypto when running `mix deps.compile` in an app that uses `event_bus`.


### Changes

- [x] Add `:crypto` to `:extra_applications` in mix.exs

### Is it ready?

- [x] Created an issue and defined what the problem is
- [x] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [ ] Added specs and docs if a new function introduced
- [ ] Updated specs and docs if changed any params of a function
- [ ] Updated changelog
- [ ] Updated readme
- [x] Didn't bump the version

### References

- Issue #157 
