### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
+# Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 80
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -19,4 +19,11 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+# Ignore package tarball (built via "mix hex.build").
+event_bus-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.6.X]
+## [1.6.X] 2020-01-20
 
 - Update type names and docs for consistent naming convention (Note: there is no logic or method name change)
 - Update the Travis script to prevent breaks on merges:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Mustafa Turan
+Copyright (c) 2017 Mustafa Turan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Mustafa Turan
+Copyright (c) 2022 Mustafa Turan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # EventBus
 
 [![Build Status](https://travis-ci.org/otobus/event_bus.svg?branch=master)](https://travis-ci.org/otobus/event_bus)
-[![Hex.pm](https://img.shields.io/hexpm/v/event_bus.svg)](http://hex.pm/packages/event_bus)
-[![Hex.pm](https://img.shields.io/hexpm/dt/event_bus.svg)](https://hex.pm/packages/event_bus)
-[![Hex.pm](https://img.shields.io/hexpm/dw/event_bus.svg)](https://hex.pm/packages/event_bus)
+[![Module Version](https://img.shields.io/hexpm/v/event_bus.svg)](https://hex.pm/packages/event_bus)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/event_bus/)
+[![Total Download](https://img.shields.io/hexpm/dt/event_bus.svg)](https://hex.pm/packages/event_bus)
+[![License](https://img.shields.io/hexpm/l/event_bus.svg)](https://github.com/otobus/event_bus/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/otobus/event_bus.svg)](https://github.com/otobus/event_bus/commits/master)
 
 Traceable, extendable and minimalist event bus implementation for Elixir with built-in event store and event watcher based on ETS.
 
@@ -63,13 +65,13 @@ Traceable, extendable and minimalist event bus implementation for Elixir with bu
 
 [Wiki](https://github.com/otobus/event_bus/wiki)
 
-[Contributing](https://github.com/otobus/event_bus/blob/master/CONTRIBUTING.md)
+[Contributing](./CONTRIBUTING.md)
 
-[License](https://github.com/otobus/event_bus/blob/master/LICENSE)
+[License](./LICENSE.md)
 
-[Code of Conduct](https://github.com/otobus/event_bus/blob/master/CODE_OF_CONDUCT.md)
+[Code of Conduct](./CODE_OF_CONDUCT.md)
 
-[Questions](https://github.com/otobus/event_bus/blob/master/QUESTIONS.md)
+[Questions](./QUESTIONS.md)
 
 ## Features
 
@@ -101,11 +103,13 @@ Start using `event_bus` library in five basic steps:
 
 ## Installation
 
-The package can be installed by adding `event_bus` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `:event_bus` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:event_bus, "~> 1.6.2"}]
+  [
+    {:event_bus, "~> 1.6.2"}
+  ]
 end
 ```
 
@@ -210,7 +214,7 @@ Optional, but good to have field for all events to track when the event generato
 
 **`occurred_at` attribute**
 
-Optional, but good to have field for all events to track when the event occurred with unixtimestamp value. The library does not automatically set this value since the value depends on the timing choice.
+Optional, but good to have field for all events to track when the event occurred with unix timestamp value. The library does not automatically set this value since the value depends on the timing choice.
 
 **`ttl` attribute**
 
@@ -507,7 +511,7 @@ This feature removed with the version 1.3 to keep the core library simple. If yo
 
 ### EventBus.Metrics Library
 
-EventBus has some addons to extend its optional functionalities. One of them is `event_bus_metrics` library which comes with a UI, RESTFul endpoints and SSE streams to provide instant metrics for event_bus topics.
+EventBus has some addons to extend its optional functionalities. One of them is `event_bus_metrics` library which comes with a UI, RESTful endpoints and SSE streams to provide instant metrics for event_bus topics.
 
 [EventBus.Metrics Instructions](https://github.com/otobus/event_bus/wiki/EventBus-Metrics-and-UI)
 
@@ -531,11 +535,11 @@ A few sample addons listed below. Please do not hesitate to add your own addon t
 
 Note: The addons under [https://github.com/otobus](https://github.com/otobus) organization implemented as a sample, but feel free to use them in your project with respecting their licenses.
 
-## License
+## Copyright and License
 
 MIT
 
-Copyright (c) 2019 Mustafa Turan
+Copyright (c) 2017 Mustafa Turan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Note: The addons under [https://github.com/otobus](https://github.com/otobus) or
 
 MIT
 
-Copyright (c) 2017 Mustafa Turan
+Copyright (c) 2022 Mustafa Turan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -1,7 +1,7 @@
 defmodule EventBus do
   @moduledoc """
   Traceable, extendable and minimalist event bus implementation for Elixir with
-  built-in event store and event observation manager based on ETS
+  built-in event store and event observation manager based on ETS.
   """
 
   alias EventBus.Manager.{
@@ -65,7 +65,7 @@ defmodule EventBus do
   @type topic_patterns :: list(topic_pattern())
 
   @doc """
-  Send an event to all subscribers
+  Send an event to all subscribers.
 
   ## Examples
 
@@ -81,7 +81,7 @@ defmodule EventBus do
     as: :notify
 
   @doc """
-  Check if a topic registered
+  Check if a topic registered.
 
   ## Examples
 
@@ -95,12 +95,13 @@ defmodule EventBus do
     as: :exist?
 
   @doc """
-  List all the registered topics
+  List all the registered topics.
 
   ## Examples
 
       EventBus.topics()
       [:metrics_summed]
+
   """
   @spec topics() :: topics()
   defdelegate topics,
@@ -108,7 +109,7 @@ defmodule EventBus do
     as: :all
 
   @doc """
-  Register a topic
+  Register a topic.
 
   ## Examples
 
@@ -122,7 +123,7 @@ defmodule EventBus do
     as: :register
 
   @doc """
-  Unregister a topic
+  Unregister a topic.
 
   ## Examples
 
@@ -136,7 +137,7 @@ defmodule EventBus do
     as: :unregister
 
   @doc """
-  Subscribe a subscriber to the event bus
+  Subscribe a subscriber to the event bus.
 
   ## Examples
 
@@ -155,7 +156,7 @@ defmodule EventBus do
     as: :subscribe
 
   @doc """
-  Unsubscribe a subscriber from the event bus
+  Unsubscribe a subscriber from the event bus.
 
   ## Examples
 
@@ -175,7 +176,7 @@ defmodule EventBus do
 
   @doc """
   Check if the given subscriber subscribed to the event bus for the given topic
-  patterns
+  patterns.
 
   ## Examples
 
@@ -198,7 +199,7 @@ defmodule EventBus do
     as: :subscribed?
 
   @doc """
-  List the subscribers
+  List the subscribers.
 
   ## Examples
 
@@ -216,7 +217,7 @@ defmodule EventBus do
     as: :subscribers
 
   @doc """
-  List the subscribers for the given topic
+  List the subscribers for the given topic.
 
   ## Examples
 
@@ -234,7 +235,7 @@ defmodule EventBus do
     as: :subscribers
 
   @doc """
-  Fetch an event
+  Fetch an event.
 
   ## Examples
 
@@ -248,7 +249,7 @@ defmodule EventBus do
     as: :fetch
 
   @doc """
-  Fetch an event's data
+  Fetch an event's data.
 
   ## Examples
 
@@ -261,9 +262,10 @@ defmodule EventBus do
     as: :fetch_data
 
   @doc """
-  Mark the event as completed for the subscriber
+  Mark the event as completed for the subscriber.
 
   ## Examples
+
       topic        = :hello_received
       event_id     = "124"
       event_shadow = {topic, event_id}
@@ -285,7 +287,7 @@ defmodule EventBus do
     as: :mark_as_completed
 
   @doc """
-  Mark the event as skipped for the subscriber
+  Mark the event as skipped for the subscriber.
 
   ## Examples
 

--- a/lib/event_bus/event_source.ex
+++ b/lib/event_bus/event_source.ex
@@ -1,6 +1,6 @@
 defmodule EventBus.EventSource do
   @moduledoc """
-  Event builder and notifier blocks/yields for EventBus
+  Event builder and notifier blocks/yields for EventBus.
   """
 
   alias EventBus.Model.Event
@@ -23,10 +23,10 @@ defmodule EventBus.EventSource do
   end
 
   @doc """
-  Dynamic event builder block with auto setters
+  Dynamic event builder block with auto setters.
 
-  It auto sets id, transaction_id, source, ttl, initialized_at and occurred_at
-  fields when they are not provided in the params
+  It auto sets `:id`, `:transaction_id`, `:source`, `:ttl`, `:initialized_at`,
+  and `:occurred_at` fields when they are not provided in the params.
   """
   defmacro build(params, do: yield) do
     quote do
@@ -58,10 +58,10 @@ defmodule EventBus.EventSource do
   end
 
   @doc """
-  Dynamic event emitter block with auto setters
+  Dynamic event emitter block with auto setters.
 
-  It auto sets id, transaction_id, source, ttl, initialized_at and occurred_at
-  fields when they are not provided in the params
+  It auto sets `:id`, `:transaction_id`, `:source`, `:ttl`, `:initialized_at`,
+  and `:occurred_at` fields when they are not provided in the params.
   """
   defmacro notify(params, do: yield) do
     quote do

--- a/lib/event_bus/models/event.ex
+++ b/lib/event_bus/models/event.ex
@@ -1,6 +1,6 @@
 defmodule EventBus.Model.Event do
   @moduledoc """
-  Structure and type for Event model
+  Structure and type for Event model.
   """
 
   @enforce_keys [:id, :topic, :data]
@@ -17,7 +17,7 @@ defmodule EventBus.Model.Event do
   ]
 
   @typedoc """
-  Definition of the Event struct
+  Definition of the Event struct.
 
   * :id - Identifier
   * :transaction_id - Transaction identifier, if event belongs to a transaction
@@ -40,8 +40,8 @@ defmodule EventBus.Model.Event do
         }
 
   @doc """
-  Calculate the duration of the event, and simple answer of how long does it
-  take to generate this event
+  Calculates the duration of the event, and simple answer of how long does it
+  take to generate this event.
   """
   @spec duration(__MODULE__.t()) :: integer()
   def duration(%__MODULE__{

--- a/lib/event_bus/utils/base62.ex
+++ b/lib/event_bus/utils/base62.ex
@@ -4,7 +4,7 @@ defmodule EventBus.Util.Base62 do
   @mapping '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 
   @doc """
-  Generates partially sequential, base62 unique identifier
+  Generates partially sequential, base62 unique identifier.
   """
   @spec unique_id() :: String.t()
   def unique_id do
@@ -12,7 +12,7 @@ defmodule EventBus.Util.Base62 do
   end
 
   @doc """
-  Converts given integer to base62
+  Converts given integer to base62.
   """
   @spec encode(integer()) :: String.t()
   def encode(num) when num < 62 do

--- a/lib/event_bus/utils/monotonic_time.ex
+++ b/lib/event_bus/utils/monotonic_time.ex
@@ -5,7 +5,7 @@ defmodule EventBus.Util.MonotonicTime do
   @eb_time_unit Application.get_env(@eb_app, :time_unit, :microsecond)
 
   @doc """
-  Calculates monotonically increasing current time
+  Calculates monotonically increasing current time.
   """
   @spec now() :: integer()
   def now do

--- a/lib/event_bus/utils/regex.ex
+++ b/lib/event_bus/utils/regex.ex
@@ -3,7 +3,7 @@ defmodule EventBus.Util.Regex do
   # Regex util for event bus
 
   @doc """
-  It checks if the given list of keys includes the key
+  It checks if the given list of keys includes the key.
   """
   @spec superset?(list(String.t() | atom()), String.t() | atom()) :: boolean()
   def superset?(keys, key) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,29 +1,31 @@
 defmodule EventBus.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/mustafaturan/event_bus"
+  @version "1.6.2"
+
   def project do
     [
       app: :event_bus,
-      version: "1.6.2",
+      version: @version,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      description: description(),
       package: package(),
       deps: deps(),
+      docs: docs(),
       dialyzer: [plt_add_deps: :transitive],
-      test_coverage: [tool: ExCoveralls],
-      docs: [extras: ["README.md"]]
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger, :crypto], mod: {EventBus.Application, []}]
+    [
+      extra_applications: [:logger, :crypto],
+      mod: {EventBus.Application, []}
+    ]
   end
 
   defp elixirc_paths(:test) do
@@ -34,21 +36,12 @@ defmodule EventBus.Mixfile do
     ["lib"]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:my_dep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:credo, "~> 1.5", only: [:dev, :test]},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.13", only: [:test]},
-      {:ex_doc, "~> 0.23", only: [:dev]}
+      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false}
     ]
   end
 
@@ -62,10 +55,31 @@ defmodule EventBus.Mixfile do
   defp package do
     [
       name: :event_bus,
-      files: ["lib", "mix.exs", "README.md"],
+      description: description(),
+      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE.md"],
       maintainers: ["Mustafa Turan"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/mustafaturan/event_bus"}
+      links: %{
+        "Changelog" => "https://hexdocs.pm/event_bus/changelog.html",
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "CHANGELOG.md": [title: "Changelog"],
+        "CONTRIBUTING.md": [title: "Contributing"],
+        "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
+        "LICENSE.md": [title: "License"],
+        "QUESTIONS.md": [title: "Questions"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EventBus.Mixfile do
   use Mix.Project
 
-  @source_url "https://github.com/mustafaturan/event_bus"
+  @source_url "https://github.com/otobus/event_bus"
   @version "1.6.2"
 
   def project do


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main reference doc for this
Elixir library which leverage on latest features of ExDoc.

### Changes

- [x] Add date for each tagged release in changelog
- [x] Update the correct starting year of copyright
- [x] Add badges for quick overview of the project
- [x] Link document relatively instead of hard-coded link to GitHub
- [x] Markdown fixes
- [x] Append all relevant documents (CHANGELOG.md and etc) to the final generated HTML documentation

### Is it ready?

- [ ] Created an issue and defined what the problem is
- [ ] Fixed the defined issue
- [x] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [x] The changes don't break current functionality
- [x] All tests are covered and passing travis
- [x] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [ ] Added specs and docs if a new function introduced
- [ ] Updated specs and docs if changed any params of a function
- [ ] Updated changelog
- [ ] Updated readme
- [x] Didn't bump the version

### References

- Issue #
