### PR TITLE
Add stacktrace to error log when subscriber.process/1 fails

### DIFF
--- a/lib/event_bus.ex
+++ b/lib/event_bus.ex
@@ -81,6 +81,23 @@ defmodule EventBus do
     as: :notify
 
   @doc """
+  Send an event to all subscribers, returning the results of all the computation
+  for each subscriber. I called this `declare` as a stronger "notify" - stronger
+  because we get the results returned from each Subscriber.
+
+  ## Examples
+
+      event = %Event{id: 1, topic: :webhook_received,
+        data: %{"message" => "Hi all!"}}
+      EventBus.declare(event)
+      {:ok, [{FirstSubscriber, results}, {SecondSubscriber, results}]}
+
+  """
+  defdelegate declare(event),
+    to: Notification,
+    as: :declare
+
+  @doc """
   Check if a topic registered.
 
   ## Examples

--- a/lib/event_bus/managers/notification.ex
+++ b/lib/event_bus/managers/notification.ex
@@ -33,6 +33,15 @@ defmodule EventBus.Manager.Notification do
     GenServer.cast(__MODULE__, {:notify, event})
   end
 
+  @doc """
+  Notify event to event.topic subscribers in the current node, while
+  also returning the results of the `process/2` function of each
+  subscriber.
+  """
+  def declare(%Event{} = event) do
+    GenServer.call(__MODULE__, {:declare, event})
+  end
+
   ###########################################################################
   # PRIVATE API
   ###########################################################################
@@ -40,7 +49,11 @@ defmodule EventBus.Manager.Notification do
   @doc false
   @spec handle_cast({:notify, event()}, term()) :: no_return()
   def handle_cast({:notify, event}, state) do
-    @backend.notify(event)
+    @backend.notify(event) # results discarded...
     {:noreply, state}
+  end
+
+  def handle_call({:declare, event}, _from, state) do
+    {:reply, @backend.notify(event), state}  
   end
 end

--- a/lib/event_bus/services/notification.ex
+++ b/lib/event_bus/services/notification.ex
@@ -41,10 +41,10 @@ defmodule EventBus.Service.Notification do
 
   @spec notify_subscriber(subscriber(), event_shadow()) :: no_return()
   defp notify_subscriber({subscriber, config}, {topic, id}) do
-    subscriber.process({config, topic, id})
+    subscriber.process({topic, id})
   rescue
     error ->
-      log_error(subscriber, error)
+      log_error(subscriber, error, __STACKTRACE__)
       ObservationManager.mark_as_skipped({{subscriber, config}, {topic, id}})
   end
 
@@ -52,7 +52,7 @@ defmodule EventBus.Service.Notification do
     subscriber.process({topic, id})
   rescue
     error ->
-      log_error(subscriber, error)
+      log_error(subscriber, error, __STACKTRACE__)
       ObservationManager.mark_as_skipped({subscriber, {topic, id}})
   end
 
@@ -69,9 +69,9 @@ defmodule EventBus.Service.Notification do
     Logger.warn(msg)
   end
 
-  @spec log_error(module(), any()) :: no_return()
-  defp log_error(subscriber, error) do
-    msg = "#{subscriber}.process/1 raised an error!\n#{inspect(error)}"
-    Logger.info(msg)
+  @spec log_error(module(), any(), any()) :: no_return()
+  defp log_error(subscriber, error, stacktrace) do
+    msg = "#{subscriber}.process/1 raised an error!\n" <> Exception.format(:error, error, stacktrace)
+    Logger.error(msg)
   end
 end

--- a/lib/event_bus/services/notification.ex
+++ b/lib/event_bus/services/notification.ex
@@ -41,7 +41,7 @@ defmodule EventBus.Service.Notification do
 
   @spec notify_subscriber(subscriber(), event_shadow()) :: no_return()
   defp notify_subscriber({subscriber, config}, {topic, id}) do
-    subscriber.process({topic, id})
+    subscriber.process({config, topic, id})
   rescue
     error ->
       log_error(subscriber, error, __STACKTRACE__)

--- a/lib/event_bus/services/notification.ex
+++ b/lib/event_bus/services/notification.ex
@@ -20,23 +20,21 @@ defmodule EventBus.Service.Notification do
     subscribers = SubscriptionManager.subscribers(topic)
 
     if subscribers == [] do
-      warn_missing_topic_subscription(topic)
+      {:error, warn_missing_topic_subscription(topic)}
     else
       :ok = StoreManager.create(event)
       :ok = ObservationManager.create({subscribers, {topic, id}})
 
       notify_subscribers(subscribers, {topic, id})
     end
-
-    :ok
   end
 
   @spec notify_subscribers(subscribers(), event_shadow()) :: :ok
   defp notify_subscribers(subscribers, event_shadow) do
-    Enum.each(subscribers, fn subscriber ->
-      notify_subscriber(subscriber, event_shadow)
+    Enum.map(subscribers, fn subscriber ->
+      res = notify_subscriber(subscriber, event_shadow)
+      {subscriber, res}
     end)
-    :ok
   end
 
   @spec notify_subscriber(subscriber(), event_shadow()) :: no_return()
@@ -46,6 +44,7 @@ defmodule EventBus.Service.Notification do
     error ->
       log_error(subscriber, error, __STACKTRACE__)
       ObservationManager.mark_as_skipped({{subscriber, config}, {topic, id}})
+      {subscriber, {:error, error}}
   end
 
   defp notify_subscriber(subscriber, {topic, id}) do
@@ -54,6 +53,7 @@ defmodule EventBus.Service.Notification do
     error ->
       log_error(subscriber, error, __STACKTRACE__)
       ObservationManager.mark_as_skipped({subscriber, {topic, id}})
+      {subscriber, {:error, error}}
   end
 
   @spec registration_status(topic()) :: String.t()
@@ -66,7 +66,8 @@ defmodule EventBus.Service.Notification do
     msg =
       "Topic(:#{topic}#{registration_status(topic)}) doesn't have subscribers"
 
-    Logger.warn(msg)
+    :ok = Logger.warn(msg)
+    msg
   end
 
   @spec log_error(module(), any(), any()) :: no_return()


### PR DESCRIPTION
//cc @otobus @mustafaturan

### Description
Update logger.error function to use Stacktrace, to make tracing the source of errors easier.

### Changes
Added __STACKTRACE__ to the params when logging the error

### Is it ready?

- [ ] Created an issue and defined what the problem is
- [ ] Fixed the defined issue
- [ ] The changes have only one commit (if possible please answer the why question with your commit message, and ofcourse a commit may have multiple messages)
- [X] The changes don't break current functionality
- [ ] All tests are covered and passing travis
- [ ] Used Elixir formatter for only modified file and fixed any of them breaks current consistency. 
- [X] Added specs and docs if a new function introduced
- [X] Updated specs and docs if changed any params of a function
- [ ] Updated changelog
- [ ] Updated readme
- [X] Didn't bump the version

### References

- Issue https://github.com/otobus/event_bus/issues/169

No custom error handler, this just adds the stacktrace to the error message, which was an annoyance I had when developing.

Love this project by the way ❤️ 
